### PR TITLE
Adding feature to match Kano packages against installed ones

### DIFF
--- a/drfeedback/feedback_inspectors.py
+++ b/drfeedback/feedback_inspectors.py
@@ -177,7 +177,6 @@ class InspectorPackages(FeedbackInspector):
                     pkg_name=None
                 else:
                     pass
-                    #print '>>> found repo package', pkg_name
 
             # Concatenate the version number, found on line that follows (Version)
             if line.startswith('Version: ') and pkg_name:


### PR DESCRIPTION
- The package list is fetched from the repo server
  and they are macthed against the installed packages
  as reported by the packages logfile in the feedback
