### PR TITLE
Show widget behind top level windows

### DIFF
--- a/kano_feedback/WidgetWindow.py
+++ b/kano_feedback/WidgetWindow.py
@@ -60,6 +60,7 @@ class WidgetWindow(ApplicationWindow):
         self.wprompts.load_prompts()
         nextp=self.wprompts.get_current_prompt()
         if nextp:
+            self.set_keep_below(True)
             self.show()
             self.position_widget()
             self._shrink()


### PR DESCRIPTION
- When the widget shows up automatically upon reception of new questions
  it should display behind all top level windows. Tested on the PI.

cc @alex5imon @pazdera 
