### PR TITLE
Do not hide after "show desktop" event

### DIFF
--- a/kano_feedback/WidgetWindow.py
+++ b/kano_feedback/WidgetWindow.py
@@ -44,6 +44,9 @@ class WidgetWindow(ApplicationWindow):
             return
 
         self.position_widget()
+        # Catch the window state event to avoid minimising and losing
+        # the window
+        self.connect("window-state-event", self._unminimise_if_minimised)
 
     def hide_until_more_questions(self):
         '''
@@ -302,3 +305,9 @@ class WidgetWindow(ApplicationWindow):
     def _get_text_from_textbuffer(self, text_buffer):
         startiter, enditer = text_buffer.get_bounds()
         return text_buffer.get_text(startiter, enditer, True)
+
+    def _unminimise_if_minimised(self, window, event):
+        # Check if we are attempting to minimise the window
+        # if so, try to unminimise it
+        if event.changed_mask & Gdk.WindowState.ICONIFIED:
+            window.deiconify()

--- a/kano_feedback/WidgetWindow.py
+++ b/kano_feedback/WidgetWindow.py
@@ -271,11 +271,11 @@ class WidgetWindow(ApplicationWindow):
 
             # Also send any pending answers we may have in the cache
             for offline in self.wprompts.get_offline_answers():
-                sent_ok = send_form(title=offline[0], body=offline[1], \
-                                        question_id=offline[2], interactive=False)
+                sent_ok = send_form(title=offline[0], body=offline[1],
+                                    question_id=offline[2], interactive=False)
                 if sent_ok:
-                    self.wprompts.mark_prompt(prompt=offline[0], answer=offline[1], \
-                                                  qid=offline[2], offline=False, rotate=False)
+                    self.wprompts.mark_prompt(prompt=offline[0], answer=offline[1],
+                                              qid=offline[2], offline=False, rotate=False)
         else:
             # Could not get connection, or user doesn't want to at this time
             # Save the answer as offline to send it later


### PR DESCRIPTION
This fix should make the kano-feedback-widget reappear after restoring (or opening) any window after a "show desktop" event.

cc @carolineclark @alex5imon @skarbat 

This PR attempts to put a fix for https://github.com/KanoComputing/peldins/issues/1621, but it doesn't fix the problem fully. With these changes the feedback widget disappears when the "show desktop" event is sent, but then it reappears when any window is restored or opened.