### PR TITLE
Questions: Migrate responses to use the Kano API

### DIFF
--- a/kano_feedback/DataSender.py
+++ b/kano_feedback/DataSender.py
@@ -458,10 +458,15 @@ def send_question_response(question_id, answer, interactive=True):
 
 
     payload = {
-        'question_id': question_id,
-        'answer': answer,
         'email': get_email(),
-        'username': get_mixed_username()
+        'username': get_mixed_username(),
+        'answers': [
+            {
+                'question_id': question_id,
+                'text': answer,
+                'tags': ['os', 'feedback-widget']
+            }
+        ]
     }
 
     # Send data

--- a/kano_feedback/DataSender.py
+++ b/kano_feedback/DataSender.py
@@ -20,7 +20,7 @@ if os.environ.has_key('DISPLAY'):
 import kano.logging as logging
 from kano.utils import run_cmd, write_file_contents, ensure_dir, delete_dir, delete_file, \
     read_file_contents
-from kano_world.connection import request_wrapper
+from kano_world.connection import request_wrapper, content_type_json
 from kano_world.functions import get_email, get_mixed_username
 from kano_profile.badges import increment_app_state_variable_with_dialog
 from kano.logging import logger
@@ -456,7 +456,6 @@ def send_question_response(question_id, answer, interactive=True):
 
         return False
 
-
     payload = {
         'email': get_email(),
         'username': get_mixed_username(),
@@ -471,7 +470,8 @@ def send_question_response(question_id, answer, interactive=True):
 
     # Send data
     success, error, dummy = request_wrapper('post', '/questions/responses',
-                                            data=payload)
+                                            data=json.dumps(payload),
+                                            headers=content_type_json)
 
     if not success:
         logger.error('Error while sending feedback: {}'.format(error))

--- a/kano_feedback/WidgetWindow.py
+++ b/kano_feedback/WidgetWindow.py
@@ -15,8 +15,8 @@ from kano.gtk3.scrolled_window import ScrolledWindow
 from kano.gtk3.buttons import OrangeButton
 from kano.gtk3.apply_styles import apply_styling_to_screen, \
     apply_styling_to_widget
-from DataSender import send_form
 from kano_profile.tracker import track_action
+from kano_feedback.DataSender import send_question_response
 from kano_feedback.WidgetQuestions import WidgetPrompts
 from kano_feedback.Media import media_dir
 
@@ -268,14 +268,15 @@ class WidgetWindow(ApplicationWindow):
         answer = self._get_text_from_textbuffer(self._text.get_buffer())
         qid = self.wprompts.get_current_prompt_id()
 
-        if send_form(title=prompt, body=answer, question_id=qid):
+        if send_question_response(question_id=qid, answer=answer):
             # Connection is ok, the answer has been sent
             self.wprompts.mark_prompt(prompt, answer, qid, offline=False, rotate=True)
 
             # Also send any pending answers we may have in the cache
             for offline in self.wprompts.get_offline_answers():
-                sent_ok = send_form(title=offline[0], body=offline[1],
-                                    question_id=offline[2], interactive=False)
+                sent_ok = send_question_response(
+                    question_id=offline[2], answer=offline[1], interactive=False
+                )
                 if sent_ok:
                     self.wprompts.mark_prompt(prompt=offline[0], answer=offline[1],
                                               qid=offline[2], offline=False, rotate=False)


### PR DESCRIPTION
KanoComputing/peldins#1907
The questions shown in the feedback widget are retrieved from the Kano
API but the responses are sent to a Google Document. This isn't scalable
so migrate to use the new API endpoint which accepts the question
responses.