### PR TITLE
Added dropdown, checkbox, radiobutton, slider and text options to feedback widget

### DIFF
--- a/kano_feedback/CheckInput.py
+++ b/kano_feedback/CheckInput.py
@@ -17,7 +17,7 @@ class CheckInput(Gtk.Box):
     }
 
     def __init__(self, values, maximum, minimum):
-        super(CheckInput, self).__init__()
+        super(CheckInput, self).__init__(orientation=Gtk.Orientation.VERTICAL)
         self._maximum = maximum
         self._minimum = minimum
         self._buttons = []

--- a/kano_feedback/CheckInput.py
+++ b/kano_feedback/CheckInput.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+# CheckInput.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+
+from gi.repository import Gtk, GObject
+
+
+class CheckInput(Gtk.Box):
+    __gsignals__ = {
+        'check-changed': (GObject.SIGNAL_RUN_FIRST, None, ()),
+        'min-selected': (GObject.SIGNAL_RUN_FIRST, None, ()),
+        'min-not-selected': (GObject.SIGNAL_RUN_FIRST, None, ())
+    }
+
+    def __init__(self, values, maximum, minimum):
+        super(CheckInput, self).__init__()
+        self._maximum = maximum
+        self._minimum = minimum
+        self._buttons = []
+
+        for v in values:
+            _check = Gtk.CheckButton.new_with_label(v)
+            # The callback checks how many of the buttons have been selected,
+            # and if it's the maximum, then the remaining should be disabled
+            self.pack_start(_check, False, False, 10)
+            self._buttons.append(_check)
+            # Connect to event listener
+
+        for b in self._buttons:
+            b.connect("toggled", self._checkbutton_cb)
+
+    def get_selected_text(self):
+        selected_text = []
+        for button in self._buttons:
+            if button.get_active():
+                selected_text.append(button.get_label())
+
+        return str(selected_text)
+
+    def _checkbutton_cb(self, widget):
+        self.emit('check-changed')
+        self._set_sensitive_buttons()
+
+    def _set_sensitive_buttons(self):
+        selected = 0
+
+        for button in self._buttons:
+            if button.get_active():
+                selected += 1
+
+        if selected >= self._maximum:
+            for button in self._buttons:
+                if not button.get_active():
+                    button.set_sensitive(False)
+        else:
+            # Tell anything hooked into this widget that the min
+            # number of buttons have been selected
+            if selected >= self._minimum:
+                self.emit("min-selected")
+            else:
+                self.emit("min-not-selected")
+
+            for button in self._buttons:
+                if not button.get_active():
+                    button.set_sensitive(True)
+
+    def focusable_widget(self):
+        return (False, None)

--- a/kano_feedback/CheckInput.py
+++ b/kano_feedback/CheckInput.py
@@ -68,5 +68,11 @@ class CheckInput(Gtk.Box):
                 if not button.get_active():
                     button.set_sensitive(True)
 
-    def focusable_widget(self):
+    def get_focusable_widget(self):
+        '''
+        :returns: tuple (bool, widget)
+                  The first argument is whether there is a widget
+                  that should be focused on, the second is the
+                  widget in question
+        '''
         return (False, None)

--- a/kano_feedback/DataSender.py
+++ b/kano_feedback/DataSender.py
@@ -12,7 +12,6 @@ import os
 from os.path import expanduser
 import datetime
 import json
-import requests
 
 # Do not Import Gtk if we are not bound to an X Display
 if os.environ.has_key('DISPLAY'):
@@ -21,7 +20,7 @@ if os.environ.has_key('DISPLAY'):
 import kano.logging as logging
 from kano.utils import run_cmd, write_file_contents, ensure_dir, delete_dir, delete_file, \
     read_file_contents
-from kano_world.connection import request_wrapper
+from kano_world.connection import request_wrapper, content_type_json
 from kano_world.functions import get_email, get_mixed_username
 from kano_profile.badges import increment_app_state_variable_with_dialog
 from kano.logging import logger
@@ -439,51 +438,55 @@ def try_connect():
     return is_internet()
 
 
-def send_form(title, body, question_id, interactive=True):
+def send_question_response(question_id, answer, interactive=True):
     '''
     This function is used by the Feedback widget.
-    The information (title, username, body, email and question id) is sent to a
-    Google form.
+    The information (question_id, answer, username and email) is sent to an API
+    endpoint.
     '''
 
-    msgok_title='Thanks so much'
-    msgok_body='We will be in touch really soon!'
+    ok_msg_title = 'Thank you'
+    ok_msg_body = 'We will use your feedback to improve your experience'
 
     if interactive and not try_connect() or not try_login():
         # The answer will be saved as offline, act as if it was sent correctly
-        thank_you = KanoDialog(msgok_title, msgok_body)
+        thank_you = KanoDialog(ok_msg_title, ok_msg_body)
         thank_you.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
         thank_you.run()
+
         return False
 
-    # Send Google Form
-    data_to_send = {
-        'entry.55383705': title,                  # Question entry
-        'entry.226915453': get_mixed_username(),  # User entry
-        'entry.2017124825': body,                 # Reply entry
-        'entry.31617144': get_email(),            # Email entry
-        'entry.2038035421': question_id           # Question ID
+    payload = {
+        'email': get_email(),
+        'username': get_mixed_username(),
+        'answers': [
+            {
+                'question_id': question_id,
+                'text': answer,
+                'tags': ['os', 'feedback-widget']
+            }
+        ]
     }
+
     # Send data
-    form = 'https://docs.google.com/a/kano.me/forms/d/1FH-6IKeuc9t6pp4lPhncG1yz29lYuLGpFv88RRaUBgU/formResponse'
-    req = requests.post(form, data=data_to_send)
+    success, error, dummy = request_wrapper('post', '/questions/responses',
+                                            data=json.dumps(payload),
+                                            headers=content_type_json)
 
-    # No further retries or prompts in non interactive mode
-    if not interactive:
-        return ( req.ok != None )
+    if not success:
+        logger.error('Error while sending feedback: {}'.format(error))
 
-    if not req.ok:
-        logger.error('Error while sending feedback: {}'.format(req.reason))
         retry = KanoDialog(
-            'Unable to send',
-            'Error while sending your feedback. Do you want to retry?',
+            title_text='Unable to send',
+            description_text=('Error while sending your feedback. ' \
+                              'Do you want to retry?'),
             button_dict={
-                'CLOSE FEEDBACK':
+                'Close feedback'.upper():
                     {
                         'return_value': False,
                         'color': 'red'
                     },
-                'RETRY':
+                'Retry'.upper():
                     {
                         'return_value': True,
                         'color': 'green'
@@ -493,11 +496,14 @@ def send_form(title, body, question_id, interactive=True):
 
         if retry.run():
             # Try again until they say no
-            send_form(title, body, question_id)
+            return send_question_response(question_id=question_id,
+                                          answer=answer,
+                                          interactive=interactive)
 
         return False
 
-    thank_you = KanoDialog(msgok_title, msgok_body)
+
+    thank_you = KanoDialog(ok_msg_title, ok_msg_body)
     thank_you.dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
     thank_you.run()
 

--- a/kano_feedback/DropdownInput.py
+++ b/kano_feedback/DropdownInput.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+# DropdownInput.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+
+from gi.repository import Gtk, GObject
+from kano.gtk3.kano_combobox import KanoComboBox
+
+
+class DropdownInput(Gtk.Alignment):
+    __gsignals__ = {
+        'dropdown-changed': (GObject.SIGNAL_RUN_FIRST, None, ()),
+        "popup": (GObject.SIGNAL_RUN_FIRST, None, ())
+    }
+
+    def __init__(self, values):
+        super(DropdownInput, self).__init__()
+        self._combo = KanoComboBox(items=values)
+        KanoComboBox.apply_styling_to_screen()
+        self._combo.connect("selected", self._emit_value_changed)
+
+        # Propagate the dropdown widget popup signal
+        self._combo.connect("popup", self._emit_popup)
+
+        self.add(self._combo)
+
+    def get_selected_text(self):
+        return self._combo.get_selected_item_text()
+
+    def _emit_value_changed(self, widget):
+        self.emit('dropdown-changed')
+
+    def _emit_popup(self, widget):
+        self.emit('popup')
+
+    def focusable_widget(self):
+        return (True, self._combo)

--- a/kano_feedback/DropdownInput.py
+++ b/kano_feedback/DropdownInput.py
@@ -36,5 +36,11 @@ class DropdownInput(Gtk.Alignment):
     def _emit_popup(self, widget):
         self.emit('popup')
 
-    def focusable_widget(self):
+    def get_focusable_widget(self):
+        '''
+        :returns: tuple (bool, widget)
+                  The first argument is whether there is a widget
+                  that should be focused on, the second is the
+                  widget in question
+        '''
         return (True, self._combo)

--- a/kano_feedback/RadioInput.py
+++ b/kano_feedback/RadioInput.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+# RadioInput.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+
+from gi.repository import Gtk, GObject
+
+
+class RadioInput(Gtk.Box):
+    __gsignals__ = {
+        'radio-changed': (GObject.SIGNAL_RUN_FIRST, None, ())
+    }
+
+    def __init__(self, values):
+        super(RadioInput, self).__init__()
+        buttons = []
+
+        # First value is treated differently
+        first_value = values[0]
+        self._first_radio = Gtk.RadioButton.new_with_label(None, first_value)
+        self._first_radio.connect(
+            'toggled',
+            self._emit_value_changed,
+            first_value
+        )
+        self.pack_start(self._first_radio, False, False, 20)
+        values.pop(0)
+
+        for v in values:
+            radio = Gtk.RadioButton.new_with_label_from_widget(
+                self._first_radio, v
+            )
+            self.pack_start(radio, False, False, 10)
+            buttons.append(radio)
+
+    def _emit_value_changed(self, widget, value):
+        self.emit('radio-changed')
+
+    def get_selected_text(self):
+        group = self._first_radio.get_group()
+        for button in group:
+            if button.get_active():
+                return str(button.get_label())
+
+        print "no selected text for radiobuttons"
+
+    def focusable_widget(self):
+        return (False, None)

--- a/kano_feedback/RadioInput.py
+++ b/kano_feedback/RadioInput.py
@@ -47,5 +47,11 @@ class RadioInput(Gtk.Box):
 
         print "no selected text for radiobuttons"
 
-    def focusable_widget(self):
+    def get_focusable_widget(self):
+        '''
+        :returns: tuple (bool, widget)
+                  The first argument is whether there is a widget
+                  that should be focused on, the second is the
+                  widget in question
+        '''
         return (False, None)

--- a/kano_feedback/RadioInput.py
+++ b/kano_feedback/RadioInput.py
@@ -15,7 +15,7 @@ class RadioInput(Gtk.Box):
     }
 
     def __init__(self, values):
-        super(RadioInput, self).__init__()
+        super(RadioInput, self).__init__(orientation=Gtk.Orientation.VERTICAL)
         buttons = []
 
         # First value is treated differently

--- a/kano_feedback/SliderInput.py
+++ b/kano_feedback/SliderInput.py
@@ -47,5 +47,11 @@ class SliderInput(Gtk.Box):
     def get_selected_text(self):
         return str(self._scale.get_value())
 
-    def focusable_widget(self):
+    def get_focusable_widget(self):
+        '''
+        :returns: tuple (bool, widget)
+                  The first argument is whether there is a widget
+                  that should be focused on, the second is the
+                  widget in question
+        '''
         return (True, self._scale)

--- a/kano_feedback/SliderInput.py
+++ b/kano_feedback/SliderInput.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+# SliderInput.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+
+from gi.repository import Gtk, GObject
+
+
+class SliderInput(Gtk.Box):
+    __gsignals__ = {
+        'slider-changed': (GObject.SIGNAL_RUN_FIRST, None, ())
+    }
+
+    def __init__(self, start, end):
+        super(SliderInput, self).__init__(orientation=Gtk.Orientation.VERTICAL)
+
+        self._start = start
+        self._end = end
+
+        # Make the selected value the halfway point
+        value = int((start + end) / 2)
+
+        self._scale = Gtk.HScale(
+            adjustment=Gtk.Adjustment(
+                value=value,
+                lower=start,
+                upper=end,
+                step_increment=1,
+                page_incr=0,
+                page_size=0
+            )
+        )
+        self._scale.set_digits(0)
+        self._scale.connect('value-changed', self._emit_value_changed)
+
+        slider_align = Gtk.Alignment(xalign=0, yalign=0, xscale=1, yscale=1)
+        slider_align.add(self._scale)
+
+        self.pack_start(slider_align, False, False, 0)
+
+    def _emit_value_changed(self, widget):
+        self.emit('slider-changed')
+
+    def get_selected_text(self):
+        return str(self._scale.get_value())
+
+    def focusable_widget(self):
+        return (True, self._scale)

--- a/kano_feedback/TextInput.py
+++ b/kano_feedback/TextInput.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+# TextInput.py
+#
+# Copyright (C) 2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+
+from gi.repository import Gtk, GObject
+
+
+class TextInput(Gtk.Alignment):
+    __gsignals__ = {
+        'text-changed': (GObject.SIGNAL_RUN_FIRST, None, ()),
+        'text-not-changed': (GObject.SIGNAL_RUN_FIRST, None, ())
+    }
+
+    def __init__(self):
+        super(TextInput, self).__init__()
+        self._textview = Gtk.TextView()
+        self._textview.get_style_context().add_class('active')
+        self._textview.set_hexpand(False)
+        self._textview.set_vexpand(False)
+        self._textview.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        self._textview.get_buffer().connect('changed', self._text_changed)
+
+        self.add(self._textview)
+
+    def focusable_widget(self):
+        return (True, self._textview)
+
+    def _get_text_from_textbuffer(self, text_buffer):
+        startiter, enditer = text_buffer.get_bounds()
+        return text_buffer.get_text(startiter, enditer, True)
+
+    def _text_changed(self, text_buffer):
+        buff_text = self._get_text_from_textbuffer(text_buffer)
+
+        # Only allow answers containing non-space text
+        enable_send = len(buff_text.strip('\t\n ')) > 0
+
+        if enable_send:
+            self.emit('text-changed')
+        else:
+            self.emit('text-not-changed')
+
+    def _emit_value_changed(self, widget):
+        self.emit('text-changed')
+
+    def get_selected_text(self):
+        textbuffer = self._textview.get_buffer()
+        return self._get_text_from_textbuffer(textbuffer)

--- a/kano_feedback/TextInput.py
+++ b/kano_feedback/TextInput.py
@@ -7,9 +7,10 @@
 #
 
 from gi.repository import Gtk, GObject
+from kano.gtk3.scrolled_window import ScrolledWindow
 
 
-class TextInput(Gtk.Alignment):
+class TextInput(ScrolledWindow):
     __gsignals__ = {
         'text-changed': (GObject.SIGNAL_RUN_FIRST, None, ()),
         'text-not-changed': (GObject.SIGNAL_RUN_FIRST, None, ())
@@ -17,6 +18,12 @@ class TextInput(Gtk.Alignment):
 
     def __init__(self):
         super(TextInput, self).__init__()
+
+        self.set_hexpand(True)
+        self.set_vexpand(True)
+        self.set_policy(Gtk.PolicyType.AUTOMATIC,
+                        Gtk.PolicyType.AUTOMATIC)
+
         self._textview = Gtk.TextView()
         self._textview.get_style_context().add_class('active')
         self._textview.set_hexpand(False)

--- a/kano_feedback/TextInput.py
+++ b/kano_feedback/TextInput.py
@@ -26,9 +26,6 @@ class TextInput(Gtk.Alignment):
 
         self.add(self._textview)
 
-    def focusable_widget(self):
-        return (True, self._textview)
-
     def _get_text_from_textbuffer(self, text_buffer):
         startiter, enditer = text_buffer.get_bounds()
         return text_buffer.get_text(startiter, enditer, True)
@@ -50,3 +47,12 @@ class TextInput(Gtk.Alignment):
     def get_selected_text(self):
         textbuffer = self._textview.get_buffer()
         return self._get_text_from_textbuffer(textbuffer)
+
+    def get_focusable_widget(self):
+        '''
+        :returns: tuple (bool, widget)
+                  The first argument is whether there is a widget
+                  that should be focused on, the second is the
+                  widget in question
+        '''
+        return (True, self._textview)

--- a/kano_feedback/WidgetQuestions.py
+++ b/kano_feedback/WidgetQuestions.py
@@ -4,7 +4,7 @@
 # WidgetQuestions.py
 #
 # Copyright (C) 2015 Kano Computing Ltd.
-# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 # Provides a rotating list of questions pulled from Kano
 #

--- a/kano_feedback/WidgetQuestions.py
+++ b/kano_feedback/WidgetQuestions.py
@@ -10,12 +10,11 @@
 #
 
 import os
-import json
 import csv
-import requests
 import time
 from kano.network import is_internet
 from kano_profile.tracker import track_data
+from kano_world.connection import request_wrapper
 from kano.logging import logger
 
 
@@ -30,7 +29,6 @@ class WidgetPrompts:
     def __init__(self):
         # The default prompt is used in the unlikely event
         # there are no more questions to be answered
-        self.kano_questions_api = 'http://api.kano.me/questions'
         self.cache_file = os.path.join(os.path.expanduser('~'),
                                        '.feedback-widget-sent.csv')
 
@@ -130,24 +128,35 @@ class WidgetPrompts:
         Get the prompts/questions through a request,
         retrying <num_retries> if network is not up.
         '''
-        for retry in range(0, num_retries):
+        for attempt in xrange(0, num_retries):
+            if attempt != 0:
+                time.sleep(2)
+
+            if not is_internet():
+                continue
+
             try:
-                if is_internet():
-                    # Contact Kano questions API
-                    questions = requests.get(self.kano_questions_api).text
-                    preloaded = json.loads(questions)
+                # Contact Kano questions API
+                success, error, res = request_wrapper('get', '/questions')
 
-                    prompts = sorted(preloaded['questions'], key=lambda k: k['date_created'])
-                    if len(prompts):
-                        self.prompts = prompts
-                        return True
-                    else:
-                        self.prompts = None
-                        return False
-            except Exception as e:
-                logger.debug("Exception in _load_remote_prompts: {}".format(str(e)))
+                if not success:
+                    logger.warn('Error loading prompts from API (try {}): {}'
+                                .format(attempt, error))
+                    continue
 
-            time.sleep(2)
+                prompts = sorted(res['questions'],
+                                 key=lambda k: k['date_created'])
+
+                if not len(prompts):
+                    return False
+
+                self.prompts = prompts
+
+                return True
+
+            except Exception as exception:
+                logger.error('Error loading prompts (try {}): {}'
+                             .format(attempt, exception))
 
         return False
 

--- a/kano_feedback/WidgetWindow.py
+++ b/kano_feedback/WidgetWindow.py
@@ -331,7 +331,7 @@ class WidgetWindow(ApplicationWindow):
         self._send.show()
         self._expanded = True
 
-        (focusable, focus_widget) = self._input_widget.focusable_widget()
+        (focusable, focus_widget) = self._input_widget.get_focusable_widget()
         if focusable:
             self.set_focus(focus_widget)
 

--- a/kano_feedback/WidgetWindow.py
+++ b/kano_feedback/WidgetWindow.py
@@ -15,8 +15,8 @@ from kano.gtk3.scrolled_window import ScrolledWindow
 from kano.gtk3.buttons import OrangeButton
 from kano.gtk3.apply_styles import apply_styling_to_screen, \
     apply_styling_to_widget
-from DataSender import send_form
 from kano_profile.tracker import track_action
+from kano_feedback.DataSender import send_question_response
 from kano_feedback.WidgetQuestions import WidgetPrompts
 from kano_feedback.Media import media_dir
 from kano_feedback.SliderInput import SliderInput
@@ -368,14 +368,15 @@ class WidgetWindow(ApplicationWindow):
 
         qid = self.wprompts.get_current_prompt_id()
 
-        if send_form(title=prompt, body=answer, question_id=qid):
+        if send_question_response(question_id=qid, answer=answer):
             # Connection is ok, the answer has been sent
             self.wprompts.mark_prompt(prompt, answer, qid, offline=False, rotate=True)
 
             # Also send any pending answers we may have in the cache
             for offline in self.wprompts.get_offline_answers():
-                sent_ok = send_form(title=offline[0], body=offline[1],
-                                    question_id=offline[2], interactive=False)
+                sent_ok = send_question_response(
+                    question_id=offline[2], answer=offline[1], interactive=False
+                )
                 if sent_ok:
                     self.wprompts.mark_prompt(prompt=offline[0], answer=offline[1],
                                               qid=offline[2], offline=False, rotate=False)

--- a/media/css/widget.css
+++ b/media/css/widget.css
@@ -70,3 +70,20 @@ GtkTextView.active {
     color: @active_writing;
     font: Bariol 13;
 }
+
+GtkCheckButton GtkLabel:insensitive {
+    background: transparent;
+}
+
+GtkScale {
+    background: #dddddd;
+    border-radius: 3px;
+}
+
+GtkScale.slider:insensitive {
+    background: #bbbbbb;
+}
+
+GtkScale.slider {
+    background: @kano_green;
+}


### PR DESCRIPTION
Been testing locally with questions of the form:
```
{"questions": [
{"text": "Radio test", "version": 1, "id": "56e5e88a86b17e08007c77f1", "tags": [], "date_created": "2015-02-19T13:43:38.273Z", "type": "radio", "choices": [2, 10, "blah blah"]},
{"text": "On a scale of 1 to 10, how likely is it that you would recommend Kano to a friend?", "version": 2, "id": "54e71d8ab7d3e90800a33928", "tags": [], "date_created": "2015-02-20T11:42:02.567Z", "type": "slider", "start": 2, "end": 10},
{"text": "What's your least favorite part of Kano?", "version": 1, "id": "5309b6b84c6ee80800f5144f", "tags": [], "date_created": "2015-03-18T17:32:40.293Z", "type": "checkbox", "choices": ["1", "2", "3", "blah blah blha"], "max_selected": 3, "min_selected": 2},
{"text": "Did you find something confusing on Kano?", "version": 1, "id": "5509b6cb609a590a0036e9f3", "tags": [], "date_created": "2015-03-18T17:32:59.092Z", "type": "dropdown", "choices": [4, 5, "lala"]},
{"text": "What should Kano make next?", "version": 1, "id": "5509b6e416a7a20700dd5c55", "tags": [], "date_created": "2015-03-18T17:33:24.125Z", "type": "radio", "choices": ["blah", "blah"]}
]}
```
Is this consistent with what I should expect to receive from the API?

Screenshots:
![kano-screenshot-mon-sep-28-14-10-35](https://cloud.githubusercontent.com/assets/5319573/10136532/eeb082e0-65ec-11e5-8128-2d4c60976bd5.png)
![kano-screenshot-mon-sep-28-14-14-58](https://cloud.githubusercontent.com/assets/5319573/10136536/f3b71b1e-65ec-11e5-8dbe-94cce5d64c02.png)
![kano-screenshot-mon-sep-28-14-16-14](https://cloud.githubusercontent.com/assets/5319573/10136540/fbdfd6dc-65ec-11e5-8926-cb3717f3aeb0.png)
![kano-screenshot-mon-sep-28-14-27-40](https://cloud.githubusercontent.com/assets/5319573/10136624/537f651a-65ed-11e5-9c24-c9f8db43c16e.png)

Needs this minor change to the API for the slider: https://github.com/KanoComputing/kano-web-api/pull/247
It turns out that the step increment option in the Gtk.Scale only affects the step increment when the Gtk.Scale is controlled by the keyboard, so I've not included the increment option in the API.

Should we add some tests here? https://github.com/KanoComputing/kano-web-api/blob/6426b6133d4716f6dab11a66b70f5cc52a138caa/test/tests/question-responses.js