### PR TITLE
Fix widget not terminating under systemd

### DIFF
--- a/bin/kano-feedback-widget
+++ b/bin/kano-feedback-widget
@@ -26,9 +26,8 @@ def main():
     # initialise the window
     WidgetWindow()
 
-    # Protect against all SIGTERM signals
+    # Protect against SIGTERM signals, to close it use "kill -9"
     if len(sys.argv) > 1 and sys.argv[1] == '--no-kill':
-        # app can be closed via a "kill -9".
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
 
     Gtk.main()

--- a/bin/kano-feedback-widget
+++ b/bin/kano-feedback-widget
@@ -26,8 +26,10 @@ def main():
     # initialise the window
     WidgetWindow()
 
-    # Ignore all SIGTERM signals, app can be closed via a "kill -9".
-    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    # Protect against all SIGTERM signals
+    if len(sys.argv) > 1 and sys.argv[1] == '--no-kill':
+        # app can be closed via a "kill -9".
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
 
     Gtk.main()
     return 0


### PR DESCRIPTION
 * When switching to dashboard via systemd, feedback was still running
 * This was due to a protection against kill signals
 * Fixed by offering a command line option to set signal, not set by default

cc @Ealdwulf 