### PR TITLE
Adding exception list to Kano Questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,18 @@ This is a simple dialogue to share thougts, feedback...
 ![Contact Us](http://i.imgur.com/MjOm1XG.png)  
 
 ##### Report a Problem
-This tool let you report an issue in the system. It not only shares the title and description with us, but also a list of useful files and diagnoses to help us find and fix the problem.  
+This tool let you report an issue in the system. It not only shares the title and description with us,
+but also a list of useful files and diagnoses to help us find and fix the problem.  
 ![Report a Problem](http://i.imgur.com/a9AYABN.png)  
 
 ##### Desktop widget
-Through this tool we can push any question to all our users.  
+Through this tool we can push any question to all our users, so Kano gets valuable feedback
+from the community.
 ![expanded](http://i.imgur.com/MZrlW2O.png)  
+
+The questions are pulled by the widget from `http://api.kano.me/questions`.
+
+The feedback widget is currently being migrated to the Dashboard.
+
 
 For more information please visit the [wiki](https://github.com/KanoComputing/kano-feedback/wiki)

--- a/kano_feedback/WidgetQuestions.py
+++ b/kano_feedback/WidgetQuestions.py
@@ -188,6 +188,9 @@ class WidgetPrompts:
         Jump to the next available question that has not been answered yet
         '''
 
+        # Question IDs being migrated to the Dashboard will go in this list
+        disabled_qids = [ "5787ac06e98ae8816fb86b15" ]
+
         next_prompt = None
         iterations = 0
         try:
@@ -198,9 +201,13 @@ class WidgetPrompts:
                     self.current_prompt_idx = 0
 
                 next_prompt = self.prompts[self.current_prompt_idx]['text']
+                next_prompt_id = self.prompts[self.current_prompt_idx]['id']
 
-                # prompt has not been answered yet, take it!
-                if not self._cache_is_prompt_responded(next_prompt):
+                # prompt has not been answered yet, take it,
+                # unless it is in the "disabled" list.
+                if not self._cache_is_prompt_responded(next_prompt) and \
+                   next_prompt_id not in disabled_qids:
+
                     return next_prompt
 
                 iterations += 1


### PR DESCRIPTION
 * An exception list allows to discard question from the Questions API server
 * Allows to gradually migrate them to the Dashboard
 * This changeset migrates the first question for next release

This PR softly plays along (no code dependency) with: https://github.com/KanoComputing/os-dashboard/pull/226

@tombettany 
