### PR TITLE
Feedback network API now supports multiple questions

### DIFF
--- a/bin/kano-feedback-widget-cli
+++ b/bin/kano-feedback-widget-cli
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     if args['--debug']:
         print 'Sending response to the server...'
 
-    is_sent=send_question_response((question_ids, answers), interactive=False,
+    is_sent=send_question_response(zip(question_ids, answers), interactive=False,
                                    debug=args['--debug'], dry_run=args['--dry-run'])
 
     if args['--debug']:

--- a/bin/kano-feedback-widget-cli
+++ b/bin/kano-feedback-widget-cli
@@ -12,13 +12,17 @@
 """Kano Feedback Widget CLI
 
 Usage:
-  kano-feedback-widget-cli <qid> <response>
+  kano-feedback-widget-cli [--dry-run] [--debug] --question=<response>...
 
 Options:
-  -h --help     Show this screen.
+  --question=<response>    String in the form "qid:response", multiple questions accepted
+  --dry-run                Do not actually send it to the network (success is assumed)
+  --debug                  Display progress and payload information
+  -h --help                Show this screen.
 
 """
 
+import os
 import sys
 from docopt import docopt
 
@@ -26,10 +30,18 @@ if __name__ == '__main__':
 
     # collect command line arguments
     args = docopt(__doc__, version="Kano Feedback")
-    question_id=args['<qid>']
-    response=args['<response>']
 
+    # Momentarily unbind from the X Server so that no heavyweight Gtk runtime is loaded
+    del os.environ['DISPLAY']
     from kano_feedback.DataSender import send_question_response
-    is_sent=send_question_response(question_id, response, interactive=False)
+
+    if args['--debug']:
+        print 'Sending response to the server...'
+
+    is_sent=send_question_response(args['--question'], interactive=False,
+                                   debug=args['--debug'], dry_run=args['--dry-run'])
+
+    if args['--debug']:
+        print 'Result: {}'.format(is_sent)
 
     sys.exit(not is_sent)

--- a/bin/kano-feedback-widget-cli
+++ b/bin/kano-feedback-widget-cli
@@ -12,7 +12,7 @@
 """Kano Feedback Widget CLI
 
 Usage:
-  kano-feedback-widget-cli [--dry-run] [--debug] --question=<response>...
+  kano-feedback-widget-cli [--dry-run] [--debug] (<question_id> <response>)...
 
 Options:
   --question=<response>    String in the form "qid:response", multiple questions accepted
@@ -31,6 +31,9 @@ if __name__ == '__main__':
     # collect command line arguments
     args = docopt(__doc__, version="Kano Feedback")
 
+    question_ids=list(args['<question_id>'])
+    answers=list(args['<response>'])
+
     # Momentarily unbind from the X Server so that no heavyweight Gtk runtime is loaded
     del os.environ['DISPLAY']
     from kano_feedback.DataSender import send_question_response
@@ -38,7 +41,7 @@ if __name__ == '__main__':
     if args['--debug']:
         print 'Sending response to the server...'
 
-    is_sent=send_question_response(args['--question'], interactive=False,
+    is_sent=send_question_response((question_ids, answers), interactive=False,
                                    debug=args['--debug'], dry_run=args['--dry-run'])
 
     if args['--debug']:

--- a/bin/kano-feedback-widget-cli
+++ b/bin/kano-feedback-widget-cli
@@ -15,7 +15,6 @@ Usage:
   kano-feedback-widget-cli [--dry-run] [--debug] (<question_id> <response>)...
 
 Options:
-  --question=<response>    String in the form "qid:response", multiple questions accepted
   --dry-run                Do not actually send it to the network (success is assumed)
   --debug                  Display progress and payload information
   -h --help                Show this screen.

--- a/kano_feedback/DataSender.py
+++ b/kano_feedback/DataSender.py
@@ -510,7 +510,7 @@ def send_question_response(answers, interactive=True, tags=['os', 'feedback-widg
 
         if retry.run():
             # Try again until they say no
-            return send_question_response((question_id, answer), interactive=interactive)
+            return send_question_response([(question_id, answer)], interactive=interactive)
 
         return False
 

--- a/kano_feedback/DataSender.py
+++ b/kano_feedback/DataSender.py
@@ -444,9 +444,7 @@ def send_question_response(answers, interactive=True, tags=['os', 'feedback-widg
     This function is used by the Feedback widget to network-send the responses.
     The information (question_id, answer, username and email) is sent to a Kano API endpoint.
 
-    the answers argument is a list of strings with answers to questions, in the following format:
-
-     12345:"answer to question id 12345"
+    answers is a list of tuples each having a Question ID and an Answer literal.
 
     The answers will be all packed into a payload object and sent in one single network transaction.
     '''
@@ -465,12 +463,12 @@ def send_question_response(answers, interactive=True, tags=['os', 'feedback-widg
     payload = {
         'email': get_email(),
         'username': get_mixed_username(),
-        'answers': []
+        'answers': [
+            { 'question_id': answer[0],
+              'text': answer[1],
+              'tags': tags } for answer in answers
+        ]
     }
-
-    for q in answers:
-        answer_block = { 'question_id': q.split(':')[0], 'text': q.split(':')[1], 'tags': tags }
-        payload['answers'].append (answer_block)
 
     if debug:
         print 'PAYLOAD construction:'

--- a/kano_feedback/DataSender.py
+++ b/kano_feedback/DataSender.py
@@ -510,8 +510,7 @@ def send_question_response(answers, interactive=True, tags=['os', 'feedback-widg
 
         if retry.run():
             # Try again until they say no
-            answer='{}:{}'.format(question_id, answer)
-            return send_question_response([answer], interactive=interactive)
+            return send_question_response((question_id, answer), interactive=interactive)
 
         return False
 

--- a/kano_feedback/WidgetWindow.py
+++ b/kano_feedback/WidgetWindow.py
@@ -367,15 +367,15 @@ class WidgetWindow(ApplicationWindow):
 
         qid = self.wprompts.get_current_prompt_id()
 
-        if send_question_response(question_id=qid, answer=answer):
+        answer='{}:{}'.format(qid, answer)
+        if send_question_response([answer])
             # Connection is ok, the answer has been sent
             self.wprompts.mark_prompt(prompt, answer, qid, offline=False, rotate=True)
 
             # Also send any pending answers we may have in the cache
             for offline in self.wprompts.get_offline_answers():
-                sent_ok = send_question_response(
-                    question_id=offline[2], answer=offline[1], interactive=False
-                )
+                answer='{}:{}'.format(offline[2], offline[1])
+                sent_ok = send_question_response([answer], interactive=False)
                 if sent_ok:
                     self.wprompts.mark_prompt(prompt=offline[0], answer=offline[1],
                                               qid=offline[2], offline=False, rotate=False)

--- a/kano_feedback/WidgetWindow.py
+++ b/kano_feedback/WidgetWindow.py
@@ -367,15 +367,14 @@ class WidgetWindow(ApplicationWindow):
 
         qid = self.wprompts.get_current_prompt_id()
 
-        answer='{}:{}'.format(qid, answer)
-        if send_question_response([answer])
+        # Network send to feedback API
+        if send_question_response((qid, answer))
             # Connection is ok, the answer has been sent
             self.wprompts.mark_prompt(prompt, answer, qid, offline=False, rotate=True)
 
             # Also send any pending answers we may have in the cache
             for offline in self.wprompts.get_offline_answers():
-                answer='{}:{}'.format(offline[2], offline[1])
-                sent_ok = send_question_response([answer], interactive=False)
+                sent_ok = send_question_response((offline[2], offline[1]), interactive=False)
                 if sent_ok:
                     self.wprompts.mark_prompt(prompt=offline[0], answer=offline[1],
                                               qid=offline[2], offline=False, rotate=False)

--- a/kano_feedback/WidgetWindow.py
+++ b/kano_feedback/WidgetWindow.py
@@ -368,13 +368,13 @@ class WidgetWindow(ApplicationWindow):
         qid = self.wprompts.get_current_prompt_id()
 
         # Network send to feedback API
-        if send_question_response((qid, answer))
+        if send_question_response([(qid, answer)])
             # Connection is ok, the answer has been sent
             self.wprompts.mark_prompt(prompt, answer, qid, offline=False, rotate=True)
 
             # Also send any pending answers we may have in the cache
             for offline in self.wprompts.get_offline_answers():
-                sent_ok = send_question_response((offline[2], offline[1]), interactive=False)
+                sent_ok = send_question_response([(offline[2], offline[1])], interactive=False)
                 if sent_ok:
                     self.wprompts.mark_prompt(prompt=offline[0], answer=offline[1],
                                               qid=offline[2], offline=False, rotate=False)


### PR DESCRIPTION
 * The API accepts a list of responses which are sent in one transaction
 * Added options to command-line tool to send multiple answers
 * Added debug and dry-run flags to test that the tool works correctly

@tombettany 