### PR TITLE
Fix to play well with kano-app-launcher

### DIFF
--- a/icon/feedback.app
+++ b/icon/feedback.app
@@ -10,5 +10,5 @@
 
   "packages": [],
   "dependencies": ["kano-feedback"],
-  "launch_command": "/usr/bin/kano-launcher \"/usr/bin/kano-feedback\" feedback"
+  "launch_command": "/usr/bin/kano-feedback feedback"
 }


### PR DESCRIPTION
This change will fix starting the feedback form from the Dashboard app launcher.
The reason being that `kano-launcher` starts the app in the background and returns control.
Needs more testing to make sure we don't change its behaviour elsewhere.

@tombettany @Ealdwulf 
