### PR TITLE
Debian: Generate `.pot` files for `i18n-orig` package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,7 @@
 	dh $@
 
 override_dh_auto_build:
+	cd po && make messages.pot
 	cd po && make
 	cd lxpanel-plugin && make
 	dh_auto_build


### PR DESCRIPTION
The `kano-feedback-18n-orig` package requires the `.pot` files to be
generated for them to be installed. Resolve this problem by explicitly
adding their creation to the `debian/rules` Makefile.

Package doesn't build without this.