### PR TITLE
Bumped changelog with applied changes from v3.9.2 es_AR backports

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-feedback (3.14.0-0) unstable; urgency=low
+
+  * Applied changes from v3.9.2 es_AR backports to latest
+
+ -- Team Kano <dev@kano.me>  Mon, 16 Oct 2017 15:12:00 +0100
+
 kano-feedback (3.9.2-0) unstable; urgency=low
 
   * Project i18n and Argentinian Spanish translations (backport)


### PR DESCRIPTION
This is to specify that the changes made in the es_AR image need to be rebuilt, tested, and released from master as well.