### PR TITLE
Add connection check routines for the cli

### DIFF
--- a/bin/kano-feedback-cli
+++ b/bin/kano-feedback-cli
@@ -27,6 +27,11 @@ Options:
     -d, --description=<description>
                     The description of the email when sending the logs.
                     Default is an empty string.
+    -c, --with-checks
+                    Run the Internet and Kano World checks beforehand. This
+                    will popup the apps to configure connections.
+    -j, --just-checks
+                    Same as --with-checks but the program will then exit.
     -z, --send      Send the logs to the dev servers.
     -h, --help      Show this message.
 

--- a/kano_feedback/kano_feedback_cli.py
+++ b/kano_feedback/kano_feedback_cli.py
@@ -10,6 +10,7 @@ from kano.utils.file_operations import touch
 
 from kano_feedback.DataSender import send_data, take_screenshot, \
     copy_archive_report, delete_tmp_dir
+from kano_feedback.utils import ensure_internet, ensure_kano_world_login
 from kano_feedback.paths import Path
 from kano_feedback.return_codes import RC
 
@@ -22,6 +23,16 @@ def main(args):
     """
 
     report_file = args['--output'] or Path.DEFAULT_REPORT_PATH
+
+    if args['--with-checks'] or args['--just-checks']:
+        if not ensure_internet():
+            return RC.NO_INTERNET
+
+        if not ensure_kano_world_login():
+            return RC.NO_KANO_WORLD_ACC
+
+        if args['--just-checks']:
+            return RC.SUCCESS
 
     if args['--screenshot']:
         print 'Taking a screenshot...'

--- a/kano_feedback/return_codes.py
+++ b/kano_feedback/return_codes.py
@@ -13,6 +13,8 @@ class RC(object):
     SUCCESS = 0
 
     INCORRECT_ARGS = 1
+    NO_INTERNET = 2
+    NO_KANO_WORLD_ACC = 3
 
     # kano-feedback-cli specific.
     ERROR_SEND_DATA = 10

--- a/kano_feedback/utils.py
+++ b/kano_feedback/utils.py
@@ -1,0 +1,48 @@
+# utils.py
+#
+# Copyright (C) 2018 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Utility functions used throughout this project.
+
+
+from kano.network import is_internet
+from kano_world.functions import login_using_token
+from kano.utils.shell import run_cmd
+
+
+def ensure_internet():
+    """Ensure there is an internet connection.
+
+    Check for an internet connection and uses ``kano-settings`` to configure
+    one if not setup. If the popup subsequently fails, the operation quits.
+
+    Returns:
+        bool: Whether there is an internet connection
+    """
+
+    if not is_internet():
+        run_cmd('sudo kano-settings --label no-internet', localised=True)
+        return is_internet()
+
+    return True
+
+
+def ensure_kano_world_login():
+    """Ensure user has logged in Kano World.
+
+    Checks for a login session and uses ``kano-login`` to configure one if not
+    setup. If the popup subsequently fails, the operation quits.
+
+    Returns:
+        bool: Whether there is a valid login session to Kano World
+    """
+
+    is_logged_in, error = login_using_token()
+
+    if not is_logged_in:
+        run_cmd('kano-login', localised=True)
+        is_logged_in, error = login_using_token()
+        return is_logged_in
+
+    return True


### PR DESCRIPTION
This adds an Internet and Kano World check with popups for config
since the `send_data` functions depends on both those conditions.