### PR TITLE
Removing "undervoltage" warning

### DIFF
--- a/etc/sysctl.d/kano.conf
+++ b/etc/sysctl.d/kano.conf
@@ -6,3 +6,7 @@ fs.suid_dumpable = 2
 
 # The pipe symbols executes the program passing the coredump through stdin
 kernel.core_pattern = |/usr/bin/kano-feedback-coredump %e %s %u %g %t
+
+# Sets the kernel message loglevel to 0 (KERN_EMERG) system is unusable
+# This level effectively hides the Undervoltage warning from the kernel
+kernel.printk = 0 0 0 0

--- a/etc/sysctl.d/kano.conf
+++ b/etc/sysctl.d/kano.conf
@@ -7,6 +7,6 @@ fs.suid_dumpable = 2
 # The pipe symbols executes the program passing the coredump through stdin
 kernel.core_pattern = |/usr/bin/kano-feedback-coredump %e %s %u %g %t
 
-# Sets the kernel message loglevel to 0 (KERN_EMERG) system is unusable
-# This level effectively hides the Undervoltage warning from the kernel
-kernel.printk = 0 0 0 0
+# Sets the kernel message loglevel to 1 (KERN_ALERT) action must be taken immediately
+# This level effectively hides the Undervoltage warning from the console.
+kernel.printk = 1 1 1 1


### PR DESCRIPTION
Setting the kernel loglevel to 0 removes the console message that appears during shutdown.
