### PR TITLE
[OS-293] Fix kano-toolset dependency version (Jessie)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-feedback (3.16.0-0) unstable; urgency=low
+
+  * Fix kano-toolset dependency version
+
+ -- Team Kano <dev@kano.me>  Wed, 5 Sep 2018 14:47:00 +0100
+
 kano-feedback (3.15.0-0) unstable; urgency=low
 
   * Added screen logging information to the support logs

--- a/debian/control
+++ b/debian/control
@@ -3,14 +3,28 @@ Maintainer: Team Kano <dev@kano.me>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.4
-Build-Depends: debhelper (>= 9), build-essential, pkg-config, libgtk2.0-dev,
-               lxpanel, libfm-dev, libkdesk-dev
+Build-Depends:
+    build-essential,
+    debhelper (>= 9),
+    libfm-dev,
+    libgtk2.0-dev,
+    libkdesk-dev,
+    lxpanel,
+    pkg-config
 
 Package: kano-feedback
 Architecture: any
-Depends: ${misc:Depends}, curl, kano-toolset (>= 2.4.0-1), kano-profile,
-    kano-video, kano-video-files (>=1.1-2), feh, libkdesk-dev, lsof,
-    kano-content
+Depends:
+    ${misc:Depends},
+    curl,
+    feh,
+    kano-content,
+    kano-profile,
+    kano-toolset (>= 3.15.0-0),
+    kano-video,
+    kano-video-files (>=1.1-2),
+    libkdesk-dev,
+    lsof
 Description: A tool for feedback gathering
  A tool to allow Kanux users to provide feedback
 


### PR DESCRIPTION
This fixes an issue with importing touch() function from kano-toolset
which was added in 3.15.0. The package dependency now reflects this
newer version. **This change is for Jessie.**