### PR TITLE
[OS-293] Fix kano-toolset dependency version (Stretch)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,20 @@
+kano-feedback (4.1.0-0) unstable; urgency=low
+
+  * Version bump for 3.16.0 fix forwardport
+
+ -- Team Kano <dev@kano.me>  Wed, 5 Sep 2018 14:57:00 +0100
+
 kano-feedback (4.0.0-0) unstable; urgency=low
 
   * Fix Gtk CSS styling issues for stretch
 
  -- Team Kano <dev@kano.me>  Fri, 22 June 2018 15:27:30 +0100
+
+kano-feedback (3.16.0-0) unstable; urgency=low
+
+  * Fix kano-toolset dependency version
+
+ -- Team Kano <dev@kano.me>  Wed, 5 Sep 2018 14:47:00 +0100
 
 kano-feedback (3.15.0-0) unstable; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -3,14 +3,31 @@ Maintainer: Team Kano <dev@kano.me>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.4
-Build-Depends: debhelper (>= 9), build-essential, pkg-config, libgtk2.0-dev,
-               lxpanel, lxpanel-dev, python-sphinx, libfm-dev, libkdesk-dev
+Build-Depends:
+    build-essential,
+    debhelper (>= 9),
+    libfm-dev,
+    libgtk2.0-dev,
+    libkdesk-dev,
+    lxpanel,
+    lxpanel-dev,
+    pkg-config,
+    python-sphinx
 
 Package: kano-feedback
 Architecture: any
-Depends: ${misc:Depends}, curl, kano-toolset (>= 2.4.0-1), kano-profile,
-    kano-video, kano-video-files (>=1.1-2), feh, libkdesk-dev, lsof,
-    kano-content, lxpanel
+Depends:
+    ${misc:Depends},
+    curl,
+    feh,
+    kano-content,
+    kano-profile,
+    kano-toolset (>= 3.15.0-0),
+    kano-video,
+    kano-video-files (>=1.1-2),
+    libkdesk-dev,
+    lsof,
+    lxpanel
 Description: A tool for feedback gathering
  A tool to allow Kanux users to provide feedback
 


### PR DESCRIPTION
This fixes an issue with importing touch() function from kano-toolset
which was added in 3.15.0. The package dependency now reflects this
newer version. **This change is for Stretch.**

Forward ports: https://github.com/KanoComputing/kano-feedback/pull/91