### PR TITLE
[OS-826] [Jessie Backport] Logs: Add `apt` and `dpkg` install logs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 kano-feedback (3.16.2-0) unstable; urgency=low
 
   * Backport: Improved process list log with WCHAN and a few others
+  * Backport: Add apt and dpkg install logs
 
  -- Team Kano <dev@kano.me>  Wed, 16 Jan 2019 17:34:00 +0000
 

--- a/kano_feedback/DataSender.py
+++ b/kano_feedback/DataSender.py
@@ -36,6 +36,9 @@ SCREENSHOT_PATH = TMP_DIR + SCREENSHOT_NAME
 ARCHIVE_NAME = 'bug_report.tar.gz'
 SEPARATOR = '-----------------------------------------------------------------'
 
+DPKG_LOG_PATH = '/var/log/dpkg.log'
+APT_LOG_PATH = '/var/log/apt/'
+
 
 def send_data(text, full_info, subject="", network_send=True):
     """Sends the data to our servers through a post request.
@@ -145,6 +148,8 @@ def get_metadata_archive():
         {'name': 'lsblk.txt', 'contents': get_lsblk()},
         {'name': 'sources-list.txt', 'contents': get_sources_list()},
     ]
+    file_list += get_install_logs()
+
     # Include the screenshot if it exists
     if os.path.isfile(SCREENSHOT_PATH):
         file_list.append({
@@ -497,6 +502,36 @@ def get_sources_list():
         output.append('')
 
     return '\n'.join(output)
+
+
+def get_install_logs():
+    log_list = []
+
+    log_files = [DPKG_LOG_PATH]
+    if os.path.exists(os.path.dirname(APT_LOG_PATH)):
+        log_files += [
+            os.path.join(APT_LOG_PATH, log_f)
+            for log_f in os.listdir(APT_LOG_PATH)
+        ]
+
+    for log_file in log_files:
+        if not os.path.exists(log_file):
+            continue
+
+        try:
+            with open(log_file, 'r') as log_f:
+                contents = log_f.read()
+
+            log_list.append(
+                {
+                    'name': 'install-{}'.format(os.path.basename(log_file)),
+                    'contents': contents
+                }
+            )
+        except Exception:
+            pass
+
+    return log_list
 
 
 def take_screenshot():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 #
 # conftest.py
 #
-# Copyright (C) 2018 Kano Computing Ltd.
+# Copyright (C) 2018-2019 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 # The pytest conftest file
@@ -12,3 +12,4 @@
 
 from tests.fixtures.apt_sources import *
 from tests.fixtures.console_mode import *
+from tests.fixtures.logs import *

--- a/tests/fixtures/apt_sources.py
+++ b/tests/fixtures/apt_sources.py
@@ -1,7 +1,7 @@
 #
 # apt_sources.py
 #
-# Copyright (C) 2018 Kano Computing Ltd.
+# Copyright (C) 2018-2019 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 # Test fixtures to simulate apt sources files
@@ -9,66 +9,29 @@
 
 
 import os
-import math
-import random
-import string
 import pytest
 
-
-#
-# Generate the set of all subsets
-#
-# Special thanks to:
-#     https://stackoverflow.com/questions/1482308/how-to-get-all-subsets-of-a-set-powerset#answer-1482359
-#
-def powerset(lst):
-    return reduce(
-        lambda result, x: result + [subset + [x] for subset in result],
-        lst,
-        [[]]
-    )
+from tests.fixtures.helpers import powerset, FakeFile
 
 
-def random_string(length):
-    char_selection = string.letters + ' \n'
-
-    # random.sample fails if the length required is greater than the population
-    factor = int(math.ceil(length / len(char_selection)))
-    char_selection *= factor * 3
-
-    return ''.join(
-        random.sample(char_selection, length)
-    )
-
-
-def random_file():
-    return random_string(random.randint(100, 200))
-
-
-class AptSrcFile(object):
-    def __init__(self, filepath, contents):
-        print contents
-        self.filepath = filepath
-        self.contents = contents
-
+class AptSrcFile(FakeFile):
     def __repr__(self):
         return 'AptSrcFile({})'.format(self.filepath)
-
-    def __gt__(self, other):
-        return self.filepath > other.filepath
 
 
 APT_DIR = '/etc/apt'
 APT_SRC_DIR = os.path.join(APT_DIR, 'sources.list.d')
 
 APT_SRC_FILES = [
-    AptSrcFile(os.path.join(APT_DIR, 'sources.list'), random_file()),
-    AptSrcFile(os.path.join(APT_SRC_DIR, 'kano.list'), random_file()),
-    AptSrcFile(os.path.join(APT_SRC_DIR, 'collabora.list'), random_file()),
+    AptSrcFile(os.path.join(APT_DIR, 'sources.list')),
+    AptSrcFile(os.path.join(APT_SRC_DIR, 'kano.list')),
+    AptSrcFile(os.path.join(APT_SRC_DIR, 'collabora.list')),
 ]
 
 
-@pytest.fixture(scope='function', params=powerset(APT_SRC_FILES))
+@pytest.fixture(scope='function', params=powerset(APT_SRC_FILES),
+                ids=[str(log) for log in powerset(APT_SRC_FILES)]
+)
 def apt_sources(fs, request):
     sources = sorted(request.param)
 

--- a/tests/fixtures/helpers.py
+++ b/tests/fixtures/helpers.py
@@ -1,0 +1,57 @@
+#
+# helpers.py
+#
+# Copyright (C) 2019 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Helper functions for tests
+#
+
+
+import math
+import random
+import string
+
+
+#
+# Generate the set of all subsets
+#
+# Special thanks to:
+#     https://stackoverflow.com/questions/1482308/how-to-get-all-subsets-of-a-set-powerset#answer-1482359
+#
+def powerset(lst):
+    return reduce(
+        lambda result, x: result + [subset + [x] for subset in result],
+        lst,
+        [[]]
+    )
+
+
+def random_string(length):
+    char_selection = string.letters + ' \n'
+
+    # random.sample fails if the length required is greater than the population
+    factor = int(math.ceil(length / len(char_selection)))
+    char_selection *= factor * 3
+
+    return ''.join(
+        random.sample(char_selection, length)
+    )
+
+
+def random_file():
+    return random_string(random.randint(100, 200))
+
+
+class FakeFile(object):
+    def __init__(self, filepath, contents='', log_filename=''):
+        self.filepath = filepath
+        self.contents = contents if contents else random_file()
+
+        self.log_filename = log_filename if log_filename else filepath
+
+    def __repr__(self):
+        return 'FakeFile({})'.format(self.filepath)
+
+    def __gt__(self, other):
+        return self.filepath > other.filepath

--- a/tests/fixtures/logs.py
+++ b/tests/fixtures/logs.py
@@ -1,0 +1,64 @@
+#
+# logs.py
+#
+# Copyright (C) 2019 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Test fixtures to simulate log files
+#
+
+
+import pytest
+
+from tests.fixtures.helpers import powerset, FakeFile
+
+
+class DpkgLogFile(FakeFile):
+    def __repr__(self):
+        return 'DpkgLogFile({})'.format(self.filepath)
+
+
+class AptLogFile(FakeFile):
+    def __repr__(self):
+        return 'AptLogFile({})'.format(self.filepath)
+
+
+DPKG_LOG_FILES = [
+    DpkgLogFile('/var/log/dpkg.log', log_filename='install-dpkg.log'),
+]
+APT_LOG_FILES = [
+    AptLogFile('/var/log/apt/term.log', log_filename='install-term.log'),
+    AptLogFile('/var/log/apt/history.log', log_filename='install-history.log'),
+]
+
+
+@pytest.fixture(
+    scope='function', params=powerset(DPKG_LOG_FILES),
+    ids=[str(log) for log in powerset(DPKG_LOG_FILES)]
+)
+def dpkg_logs(fs, request):
+    log_files = request.param
+
+    for log_file in log_files:
+        fs.create_file(
+            log_file.filepath,
+            contents=log_file.contents
+        )
+
+    return log_files
+
+
+@pytest.fixture(
+    scope='function', params=powerset(APT_LOG_FILES),
+    ids=[str(log) for log in powerset(APT_LOG_FILES)]
+)
+def apt_logs(fs, request):
+    log_files = request.param
+
+    for log_file in log_files:
+        fs.create_file(
+            log_file.filepath,
+            contents=log_file.contents
+        )
+
+    return log_files

--- a/tests/test_data_sender.py
+++ b/tests/test_data_sender.py
@@ -27,3 +27,22 @@ def test_get_sources_list(console_mode, apt_sources):
         for src in apt_sources
     ])
     assert src_list == expected
+
+
+def test_get_install_logs(console_mode, dpkg_logs, apt_logs):
+    import kano_feedback.DataSender as DataSender
+    # FIXME: Reload required to re-patch the module with the new fs
+    imp.reload(DataSender)
+
+    logs = DataSender.get_install_logs()
+
+    expected_logs = dpkg_logs + apt_logs
+    expected_output = [
+        {
+            'name': log.log_filename,
+            'contents': log.contents
+        }
+        for log in expected_logs
+    ]
+
+    assert logs == expected_output


### PR DESCRIPTION
Add the `apt` and `dpkg` install logs to the list of files to be
included in the submitted logs.