### PR TITLE
[OS-855] [Backport] Add memory stats

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,8 +2,9 @@ kano-feedback (3.16.2-0) unstable; urgency=low
 
   * Backport: Improved process list log with WCHAN and a few others
   * Backport: Add apt and dpkg install logs
+  * Backport: Add memory stats logs
 
- -- Team Kano <dev@kano.me>  Wed, 16 Jan 2019 17:34:00 +0000
+ -- Team Kano <dev@kano.me>  Mon, 21 Jan 2019 17:34:00 +0000
 
 kano-feedback (3.16.1-0) unstable; urgency=low
 

--- a/kano_feedback/DataSender.py
+++ b/kano_feedback/DataSender.py
@@ -2,14 +2,13 @@
 
 # DataSender.py
 #
-# Copyright (C) 2014-2018 Kano Computing Ltd.
+# Copyright (C) 2014-2019 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 # Functions related to sending feedback data
 
 
 import os
-from os.path import expanduser
 import datetime
 import json
 import traceback
@@ -17,20 +16,17 @@ import traceback
 # Do not Import Gtk if we are not bound to an X Display
 if 'DISPLAY' in os.environ:
     from gi.repository import Gtk
-
-import kano.logging as logging
-from kano.utils import run_cmd, write_file_contents, ensure_dir, delete_dir, \
-    delete_file, read_file_contents, get_rpi_model
-from kano_world.connection import request_wrapper, content_type_json
-from kano.logging import logger
-
-# Do not Import Gtk if we are not bound to an X Display
-if 'DISPLAY' in os.environ:
     from kano.gtk3.kano_dialog import KanoDialog
 
+from kano_world.connection import request_wrapper, content_type_json
 from kano.network import is_internet
+import kano.logging as logging
+from kano.logging import logger
+from kano.utils import run_cmd, write_file_contents, ensure_dir, delete_dir, \
+    delete_file, read_file_contents, get_rpi_model
 
-TMP_DIR = os.path.join(expanduser('~'), '.kano-feedback/')
+
+TMP_DIR = os.path.join(os.path.expanduser('~'), '.kano-feedback/')
 SCREENSHOT_NAME = 'screenshot.png'
 SCREENSHOT_PATH = TMP_DIR + SCREENSHOT_NAME
 ARCHIVE_NAME = 'bug_report.tar.gz'
@@ -142,6 +138,7 @@ def get_metadata_archive():
         {'name': 'screen-log.txt', 'contents': get_screen_log()},
         {'name': 'xorg-log.txt', 'contents': get_xorg_log()},
         {'name': 'cpu-info.txt', 'contents': get_cpu_info()},
+        {'name': 'mem-stats.txt', 'contents': get_mem_stats()},
         {'name': 'lsof.txt', 'contents': get_lsof()},
         {'name': 'content-objects.txt', 'contents': get_co_list()},
         {'name': 'disk-space.txt', 'contents': get_disk_space()},
@@ -292,6 +289,32 @@ def get_cpu_info():
     o += '\nModel: {}'.format(get_rpi_model())
 
     return o
+
+
+def get_mem_stats():
+    """
+    Get information about memory usage
+    """
+    mem_stats = ''
+
+    out, _, _ = run_cmd('free --human --lohi --total')
+    mem_stats += out
+    out, _, _ = run_cmd('vcgencmd get_mem arm')
+    mem_stats += out
+    out, _, _ = run_cmd('vcgencmd get_mem gpu')
+    mem_stats += out
+    out, _, _ = run_cmd('vcgencmd get_mem reloc')
+    mem_stats += out
+    out, _, _ = run_cmd('vcgencmd get_mem reloc_total')
+    mem_stats += out
+    out, _, _ = run_cmd('vcgencmd get_mem malloc')
+    mem_stats += out
+    out, _, _ = run_cmd('vcgencmd get_mem malloc_total')
+    mem_stats += out
+    out, _, _ = run_cmd('vcgencmd mem_reloc_stats')
+    mem_stats += out
+
+    return mem_stats
 
 
 def get_lsof():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,3 +13,5 @@
 from tests.fixtures.apt_sources import *
 from tests.fixtures.console_mode import *
 from tests.fixtures.logs import *
+
+from tests.fixtures.patch_toolset_paths import *

--- a/tests/fixtures/patch_toolset_paths.py
+++ b/tests/fixtures/patch_toolset_paths.py
@@ -1,0 +1,21 @@
+#
+# patch_toolset_paths.py
+#
+# Copyright (C) 2019 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Test fixture to patch silly code in kano-toolset.
+# Remove this once that is fixed.
+#
+
+
+import pytest
+
+
+@pytest.fixture(scope='function')
+def fix_toolset(fs):
+    # TODO: kano-toolset/kano/paths.py throws an exception when it cannot find
+    # a project dir. This creates problems when using other fixtures with
+    # pyfakefs since the import below will be affected. Create the dir here
+    # next to the import from kano-toolset to avoid the exception.
+    fs.create_dir('/usr/share/kano/media')

--- a/tests/test_data_sender.py
+++ b/tests/test_data_sender.py
@@ -1,7 +1,7 @@
 #
 # test_data_sender.py
 #
-# Copyright (C) 2018 Kano Computing Ltd.
+# Copyright (C) 2018-2019 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 # Tests that the data is correctly collected and sent
@@ -11,7 +11,7 @@
 import imp
 
 
-def test_get_sources_list(console_mode, apt_sources):
+def test_get_sources_list(fix_toolset, console_mode, apt_sources):
     import kano_feedback.DataSender as DataSender
     # FIXME: Reload required to re-patch the module with the new fs
     imp.reload(DataSender)


### PR DESCRIPTION
Example of `mem-stats.txt`
```
              total        used        free      shared  buff/cache   available
Mem:           748M        306M        305M         39M        136M        372M
Low:           748M        443M        305M
High:            0B          0B          0B
Swap:            0B          0B          0B
Total:         748M        306M        305M
arm=768M
gpu=256M
reloc=170M
reloc_total=236M
malloc=10M
malloc_total=12M
alloc failures:     0
compactions:        0
legacy block fails: 0
```

Backport for Jessie of https://github.com/KanoComputing/kano-feedback/pull/101