### PR TITLE
[OS-855] Enhanced mem-stats.txt log

### DIFF
--- a/kano_feedback/DataSender.py
+++ b/kano_feedback/DataSender.py
@@ -302,7 +302,7 @@ def get_mem_stats():
     mem_stats = ''
 
     out, _, _ = run_cmd('free --human --lohi --total')
-    mem_stats += out
+    mem_stats += out + '\n'
     out, _, _ = run_cmd('vcgencmd get_mem arm')
     mem_stats += out
     out, _, _ = run_cmd('vcgencmd get_mem gpu')
@@ -314,8 +314,12 @@ def get_mem_stats():
     out, _, _ = run_cmd('vcgencmd get_mem malloc')
     mem_stats += out
     out, _, _ = run_cmd('vcgencmd get_mem malloc_total')
-    mem_stats += out
+    mem_stats += out + '\n'
     out, _, _ = run_cmd('vcgencmd mem_reloc_stats')
+    mem_stats += out + '\n'
+    out, _, _ = run_cmd('cat /proc/meminfo')
+    mem_stats += out + '\n'
+    out, _, _ = run_cmd('ps -eo pmem,args --no-headers --sort -pmem')
     mem_stats += out
 
     return mem_stats


### PR DESCRIPTION
Added a proc list sorted by %mem usage and a cat of /proc/meminfo. Example mem-stats.txt:

```
              total        used        free      shared  buff/cache   available
Mem:           748M        199M        134M         39M        414M        477M
Low:           748M        614M        134M
High:            0B          0B          0B
Swap:            0B          0B          0B
Total:         748M        199M        134M

arm=768M
gpu=256M
reloc=170M
reloc_total=236M
malloc=10M
malloc_total=12M

alloc failures:     0
compactions:        0
legacy block fails: 0

MemTotal:         766752 kB
MemFree:          136884 kB
MemAvailable:     488072 kB
Buffers:           29948 kB
Cached:           370384 kB
SwapCached:            0 kB
Active:           356292 kB
Inactive:         222380 kB
Active(anon):     205096 kB
Inactive(anon):    13704 kB
Active(file):     151196 kB
Inactive(file):   208676 kB
Unevictable:           0 kB
Mlocked:               0 kB
SwapTotal:             0 kB
SwapFree:              0 kB
Dirty:                92 kB
Writeback:             0 kB
AnonPages:        178272 kB
Mapped:            87568 kB
Shmem:             40464 kB
Slab:              36772 kB
SReclaimable:      24084 kB
SUnreclaim:        12688 kB
KernelStack:        1392 kB
PageTables:         2740 kB
NFS_Unstable:          0 kB
Bounce:                0 kB
WritebackTmp:          0 kB
CommitLimit:      383376 kB
Committed_AS:     661352 kB
VmallocTotal:    1294336 kB
VmallocUsed:           0 kB
VmallocChunk:          0 kB
CmaTotal:           8192 kB
CmaFree:            6784 kB

11.3 kano-dashboard -platform eglfs
 5.7 python /usr/bin/kano-feedback-cli -t t -d d
 4.6 /usr/lib/xorg/Xorg :0 -seat seat0 -auth /var/run/lightdm/root/:0 -nolisten tcp vt7 -novtswitch
 4.1 python /usr/bin/kano-boards-daemon
 3.8 /usr/bin/qmlmatrix
 3.4 python /usr/bin/kano-tracker-ctl refresh --watch
 3.1 python /usr/bin/kano-speakerleds cpu-monitor start --check
 2.1 /usr/bin/touch-home-button -d
 1.8 openbox --config-file /home/radu/.config/openbox/lxde-rc.xml
 1.5 /usr/bin/lxsession -s LXDE -e LXDE
 1.1 lxpolkit
 1.1 /usr/bin/kano-notifications -d --sound=file:////usr/share/kano-media/sounds/kano_achievement_unlock.wav --timeout=3000
 0.9 lightdm --session-child 14 17
 0.9 /usr/lib/policykit-1/polkitd --no-debug
 0.9 /usr/sbin/lightdm
 0.8 /sbin/init
 0.7 /lib/systemd/systemd --user
 0.5 kdesk -c /usr/share/kano-desktop/kdesk/kdeskrc_screensaver -s
 0.5 -bash
 0.5 /lib/systemd/systemd-logind
 0.5 -su
 0.5 /lib/systemd/systemd-journald
 0.4 /usr/lib/bluetooth/bluetoothd
 0.4 /lib/systemd/systemd-timesyncd
 0.4 /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation
 0.4 sudo kano-feedback-cli -t t -d d
 0.4 /usr/bin/sudo /usr/bin/kano-boards-daemon
 0.4 /lib/systemd/systemd-udevd
 0.4 /usr/bin/xbindkeys -f /usr/share/kano-desktop/config/keyboard/kanokeyboardrc
 0.3 /bin/su - radu
 0.3 /bin/bash /usr/bin/kano-dashboard-supervisor
 0.3 /sbin/cgmanager -m name=systemd
 0.3 avahi-daemon: running [kano-3.local]
 0.3 /usr/sbin/preload -s /var/lib/preload/preload.state
 0.3 /usr/sbin/cron -f
 0.2 ps -eo pmem,args --no-headers --sort -pmem
 0.2 wpa_supplicant -B -c/etc/wpa_supplicant/wpa_supplicant.conf -iwlan0 -Dnl80211,wext
 0.2 /usr/bin/dbus-daemon --fork --print-pid 5 --print-address 7 --session
 0.2 /usr/sbin/dropbear -p 22 -W 65536
 0.2 /sbin/wpa_supplicant -u -s -O /run/wpa_supplicant
 0.2 /usr/bin/dbus-daemon --fork --print-pid 5 --print-address 7 --session
 0.2 /sbin/dhcpcd -q -b
 0.2 /usr/bin/dbus-launch --exit-with-session --sh-syntax
 0.2 dbus-launch --autolaunch 8cbbc259a59a4e658363421ad0140da0 --binary-syntax --close-stderr
 0.1 (sd-pam)
 0.0 /bin/sh -c ps -eo pmem,args --no-headers --sort -pmem
 0.0 sh -c /usr/bin/qmlmatrix
 0.0 avahi-daemon: chroot helper
 0.0 /usr/bin/ssh-agent x-session-manager
 0.0 /usr/bin/ssh-agent -s
 0.0 /usr/bin/hciattach /dev/serial1 bcm43xx 921600 noflow - b8:27:eb:cb:46:3e
 0.0 /usr/sbin/dropbear -p 22 -W 65536
 0.0 /usr/sbin/ifplugd -i eth0 -q -f -u0 -d10 -w -I
 0.0 /usr/sbin/ifplugd -i wlan0 -q -f -u0 -d10 -w -I
 0.0 [kthreadd]
 0.0 [kworker/0:0H]
 0.0 [mm_percpu_wq]
 0.0 [ksoftirqd/0]
 0.0 [rcu_sched]
 0.0 [rcu_bh]
 0.0 [migration/0]
 0.0 [cpuhp/0]
 0.0 [cpuhp/1]
 0.0 [migration/1]
 0.0 [ksoftirqd/1]
 0.0 [kworker/1:0H]
 0.0 [cpuhp/2]
 0.0 [migration/2]
 0.0 [ksoftirqd/2]
 0.0 [kworker/2:0H]
 0.0 [cpuhp/3]
 0.0 [migration/3]
 0.0 [ksoftirqd/3]
 0.0 [kworker/3:0H]
 0.0 [kdevtmpfs]
 0.0 [netns]
 0.0 [khungtaskd]
 0.0 [oom_reaper]
 0.0 [writeback]
 0.0 [kcompactd0]
 0.0 [crypto]
 0.0 [kblockd]
 0.0 [watchdogd]
 0.0 [rpciod]
 0.0 [xprtiod]
 0.0 [kswapd0]
 0.0 [nfsiod]
 0.0 [kthrotld]
 0.0 [iscsi_eh]
 0.0 [dwc_otg]
 0.0 [DWC Notificatio]
 0.0 [vchiq-slot/0]
 0.0 [vchiq-recy/0]
 0.0 [vchiq-sync/0]
 0.0 [vchiq-keep/0]
 0.0 [SMIO]
 0.0 [irq/92-mmc1]
 0.0 [mmcqd/0]
 0.0 [jbd2/mmcblk0p7-]
 0.0 [ext4-rsv-conver]
 0.0 [spi0]
 0.0 [kworker/2:1]
 0.0 [cfg80211]
 0.0 [brcmf_wq/mmc1:0]
 0.0 [brcmf_wdog/mmc1]
 0.0 [kworker/3:2]
 0.0 [kworker/0:0]
 0.0 [kworker/2:2]
 0.0 [kworker/1:1H]
 0.0 [kworker/u8:0]
 0.0 [kworker/u9:0]
 0.0 [kworker/u9:2]
 0.0 [kworker/1:1]
 0.0 [kworker/3:1]
 0.0 [kworker/0:2]
 0.0 [kworker/3:1H]
 0.0 [kworker/0:1H]
 0.0 [kworker/2:1H]
 0.0 [kworker/u8:3]
 0.0 [kworker/1:2]
 0.0 [kworker/0:3]
 0.0 [kworker/3:0]
 0.0 [kworker/0:1]
 0.0 [kworker/u8:1]
 0.0 [kworker/1:0]
```