### PR TITLE
[OS-939] Logs: Add title and description to submitted logs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-feedback (4.3.0-0) unstable; urgency=low
+
+  * Add title and description into the log archive
+
+ -- Team Kano <dev@kano.me>  Tue, 30 Apr 2019 13:44:00 +0000
+
 kano-feedback (4.2.1-0) unstable; urgency=low
 
   * Add apt and dpkg install logs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,11 @@
 behave
 coverage-badge
 mock
-pyfakefs==3.4.3
+pyfakefs
 pytest
 pytest-cov
 pytest-flake8
 pytest-mock
+pytest-stub
 pytest-tap
+requests-mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,3 +15,4 @@ from tests.fixtures.console_mode import *
 from tests.fixtures.logs import *
 
 from tests.fixtures.patch_toolset_paths import *
+from tests.fixtures.patch_profile_paths import *

--- a/tests/fixtures/patch_profile_paths.py
+++ b/tests/fixtures/patch_profile_paths.py
@@ -1,0 +1,27 @@
+#
+# patch_profile_paths.py
+#
+# Copyright (C) 2019 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# Test fixture to patch silly code in kano-profile.
+# Remove this once that is fixed.
+#
+
+
+import pytest
+
+
+@pytest.fixture(scope='function')
+def fix_profile(fs):
+    # TODO: kano-profile/*/paths.py throws an exception when it cannot find
+    # a project dir. This creates problems when using other fixtures with
+    # pyfakefs since the import below will be affected. Create the dir here
+    # next to the import from kano-toolset to avoid the exception.
+    import os
+    fs.create_dir('/usr/share/kano-profile/rules/')
+    fs.create_dir('/usr/bin')
+    fs.create_dir('/usr/share/kano-desktop/Legal/')
+    fs.create_dir('/usr/share/kano-profile/media/')
+    fs.create_dir(os.path.expanduser('~/.kanoprofile/tracker'))
+    fs.create_file(os.path.expanduser('~/.kanoprofile/tracker/token'))

--- a/tests/test_data_sender.py
+++ b/tests/test_data_sender.py
@@ -9,6 +9,129 @@
 
 
 import imp
+import json
+from tests.fixtures.helpers import random_file
+
+
+class ExpectedFile(object):
+    def __init__(self, filename, contents, fn=''):
+        self.filename = filename
+        self.contents = contents
+        self.fn = fn
+
+    def mock_fn(self, *args, **kwargs):
+        return self.contents
+
+
+TEST_TITLE = 'Some test title'
+TEST_DESC = 'Some test decription'
+
+
+EXPECTED_FILES = [
+    ExpectedFile(filename='kanux_version.txt', fn='get_version', contents=random_file()),
+    ExpectedFile(filename='kanux_stamp.txt', fn='get_stamp', contents=random_file()),
+    ExpectedFile(filename='process.txt', fn='get_processes', contents=random_file()),
+    ExpectedFile(filename='process-tree.txt', fn='get_process_tree', contents=random_file()),
+    ExpectedFile(filename='packages.txt', fn='get_packages', contents=random_file()),
+    ExpectedFile(filename='dmesg.txt', fn='get_dmesg', contents=random_file()),
+    ExpectedFile(filename='syslog.txt', fn='get_syslog', contents=random_file()),
+    # ExpectedFile(filename='cmdline.txt', fn='read_file_fn', contents=random_file()),
+    # ExpectedFile(filename='config.txt', fn='read_file_fn', contents=random_file()),
+    ExpectedFile(filename='wifi-info.txt', fn='get_wifi_info', contents=random_file()),
+    ExpectedFile(filename='usbdevices.txt', fn='get_usb_devices', contents=random_file()),
+    ExpectedFile(filename='app-logs.txt', fn='get_app_logs_raw', contents=random_file()),
+    ExpectedFile(filename='app-logs-json.txt', fn='get_app_logs_json', contents=random_file()),
+    ExpectedFile(filename='hdmi-info.txt', fn='get_hdmi_info', contents=random_file()),
+    ExpectedFile(filename='edid.dat', fn='get_edid', contents=random_file()),
+    ExpectedFile(filename='screen-log.txt', fn='get_screen_log', contents=random_file()),
+    ExpectedFile(filename='xorg-log.txt', fn='get_xorg_log', contents=random_file()),
+    ExpectedFile(filename='cpu-info.txt', fn='get_cpu_info', contents=random_file()),
+    ExpectedFile(filename='mem-stats.txt', fn='get_mem_stats', contents=random_file()),
+    ExpectedFile(filename='lsof.txt', fn='get_lsof', contents=random_file()),
+    ExpectedFile(filename='content-objects.txt', fn='get_co_list', contents=random_file()),
+    ExpectedFile(filename='disk-space.txt', fn='get_disk_space', contents=random_file()),
+    ExpectedFile(filename='lsblk.txt', fn='get_lsblk', contents=random_file()),
+    ExpectedFile(filename='sources-list.txt', fn='get_sources_list', contents=random_file()),
+    ExpectedFile(filename='metadata.json', contents=json.dumps({'title': TEST_TITLE, 'description': TEST_DESC})),
+]
+
+
+def test_send_data(mocker, requests_mock, console_mode, monkeypatch, stub):
+    # Stub out some kano_world.functions`
+    stub.apply({
+        'kano.notifications.display_generic_notification': '[func]',
+        'kano_world.functions': {
+            'get_email': lambda: 'test@kano.me',
+            'get_mixed_username': lambda: 'testuser',
+        },
+    })
+
+    # Fake the API, in the future we might want to actually test the data
+    # sent
+    post_mock = requests_mock.post(
+        'https://api.kano.me/feedback',
+        json={'result': 200}
+    )
+
+    # Stub the get_metadata_archive()
+    import io
+
+    title = 'test title'
+    desc = 'test description'
+    archive_data = io.BytesIO(b'Fake metadata archive file')
+
+    get_archive_stub = mocker.stub()
+    get_archive_stub.side_effect = lambda *args, **kwargs: archive_data
+
+    import kano_feedback.DataSender as DataSender
+    monkeypatch.setattr(DataSender, 'get_metadata_archive', get_archive_stub)
+
+    # Call function under test
+    DataSender.send_data(desc, True, subject=title)
+
+    # Verify
+    assert len(post_mock.request_history) == 1
+
+    assert get_archive_stub.call_count == 1
+    get_archive_stub.assert_called_with(title=title, desc=desc)
+
+
+def test_get_metadata_archive(fs, monkeypatch, console_mode):
+    fs.create_dir('/var/tmp/')
+
+    import kano_feedback.DataSender as DataSender
+    fs.create_dir(DataSender.TMP_DIR)
+    imp.reload(DataSender)
+
+    for expected_f in EXPECTED_FILES:
+        if hasattr(DataSender, expected_f.fn):
+            monkeypatch.setattr(
+                DataSender, expected_f.fn, expected_f.mock_fn
+            )
+
+    # Call function under test
+    archive = DataSender.get_metadata_archive(title=TEST_TITLE, desc=TEST_DESC)
+
+    # Verify
+    import tarfile
+    import os
+
+    assert os.path.exists(os.path.join(
+        os.path.expanduser('~'), '.kano-feedback', 'bug_report.tar.gz'
+    ))
+
+    extraction_path = '/testdata'
+    fs.create_dir(extraction_path)
+
+    with tarfile.open('archive', mode='r', fileobj=archive) as archive_f:
+        archive_f.extractall(path=extraction_path)
+        assert sorted([f.filename for f in EXPECTED_FILES]) \
+            == sorted(os.listdir(extraction_path))
+
+        for expected_f in EXPECTED_FILES:
+            filepath = os.path.join(extraction_path, expected_f.filename)
+            with open(filepath, 'r') as archive_f:
+                assert expected_f.contents == archive_f.read()
 
 
 def test_get_sources_list(fix_toolset, console_mode, apt_sources):


### PR DESCRIPTION
Submit the title and description of the logged feedback as a file in the
archive to be submitted.